### PR TITLE
Refact Grid

### DIFF
--- a/OSS13 Client/Sources/Graphics/TileGrid/TileGrid.cpp
+++ b/OSS13 Client/Sources/Graphics/TileGrid/TileGrid.cpp
@@ -318,7 +318,7 @@ void TileGrid::Update(sf::Time timeElapsed) {
         }
     }
 
-	for (auto &block : blocks.Get()) {
+	for (auto &block : blocks.Items()) {
 		if (block) block->Update(timeElapsed);
 	}
     
@@ -510,7 +510,7 @@ int TileGrid::GetFOVZ() {return fovZ;}
 void TileGrid::UpdateOverlay(std::vector<network::protocol::OverlayInfo> &overlayInfo) {
 	overlayToggled = true;
 	auto tileOverlayInfo = overlayInfo.begin();
-	for (auto &tile : blocks.Get()) {
+	for (auto &tile : blocks.Items()) {
 		EXPECT(tileOverlayInfo != overlayInfo.end());
 		if (tile) {
 			tile->SetOverlay(tileOverlayInfo->text);
@@ -521,7 +521,7 @@ void TileGrid::UpdateOverlay(std::vector<network::protocol::OverlayInfo> &overla
 
 void TileGrid::ResetOverlay() {
 	overlayToggled = false;
-	for (auto &tile : blocks.Get()) {
+	for (auto &tile : blocks.Items()) {
 		if (tile)
 			tile->SetOverlay("");
 	}

--- a/OSS13 Server/Sources/World/Camera/Camera.cpp
+++ b/OSS13 Server/Sources/World/Camera/Camera.cpp
@@ -37,7 +37,7 @@ void Camera::updateOverlay(std::chrono::microseconds timeElapsed) {
 		auto command = std::make_unique<network::protocol::server::OverlayUpdateCommand>();
 
 		command->overlayInfo.reserve(getVisibleAreaSide() * getVisibleAreaSide() * getVisibleAreaHeight());
-		for (auto &[tile, _]: visibleTiles.Get()) {
+		for (auto &[tile, _]: visibleTiles.Items()) {
 			if (tile) {
 				command->overlayInfo.push_back(overlay->GetOverlayInfo(*tile));
 			}
@@ -118,7 +118,7 @@ void Camera::UpdateView(std::chrono::microseconds timeElapsed) {
 
 	std::vector<std::pair<std::shared_ptr<network::protocol::Diff>, sptr<Object>>> differencesWithObjects;
 
-	for (auto &[tile,sync]: visibleTiles.Get()) {
+	for (auto &[tile,sync]: visibleTiles.Items()) {
 		if (tile) {
 			if (sync) {
 				// Collect differences
@@ -298,22 +298,18 @@ uf::vec3i Camera::getFirstTilePos() {
 }
 
 void Camera::fullRecountVisibleBlocks() {
-	for (int z = 0; z < getVisibleAreaHeight(); z++)
-	for (int y = 0; y < getVisibleAreaSide(); y++)
-	for (int x = 0; x < getVisibleAreaSide(); x++) {
-		visibleTiles.At(x,y,z) = {tile->GetMap()->GetTile(getFirstTilePos()+vec3i(x,y,z)), false};
+	for (auto &&[pair, pos] : visibleTiles) {
+		pair = {tile->GetMap()->GetTile(getFirstTilePos() + pos), false};
 	}
 	visibleObjects.clear();
 }
 
 void Camera::fillEmptyVisibleBlocks() {
-	for (int z = 0; z < getVisibleAreaHeight(); z++)
-	for (int y = 0; y < getVisibleAreaSide(); y++)
-	for (int x = 0; x < getVisibleAreaSide(); x++) {
-		if(visibleTiles.At(x,y,z).first != nullptr) {
+	for (auto &&[pair, pos] : visibleTiles) {
+		if(pair.first != nullptr) {
 			continue;
 		}
-		visibleTiles.At(x,y,z).first = tile->GetMap()->GetTile(getFirstTilePos() + vec3i(x,y,z));
+		pair.first = tile->GetMap()->GetTile(getFirstTilePos() + pos);
 	}
 }
 

--- a/OSS13 Server/Sources/World/Camera/Camera.cpp
+++ b/OSS13 Server/Sources/World/Camera/Camera.cpp
@@ -294,7 +294,7 @@ uf::vec3i Camera::getVisibleAreaDimensions() {
 }
 
 uf::vec3i Camera::getFirstTilePos() {
-	return tile->GetPos() - vec3i(fov + Global::MIN_PADDING, fov + Global::MIN_PADDING, fovZ);
+	return tile->GetPos() - uf::vec3i(fov + Global::MIN_PADDING, fov + Global::MIN_PADDING, fovZ);
 }
 
 void Camera::fullRecountVisibleBlocks() {
@@ -320,7 +320,7 @@ void Camera::refreshVisibleBlocks() {
 	}
 
 	if (lastTile) {
-		GridTransformation transformation;
+		uf::GridTransformation transformation;
 		transformation.originDelta = tile->GetPos() - lastTile->GetPos();
 
 		visibleTiles.Transform(transformation);
@@ -332,7 +332,7 @@ void Camera::updateFOV() {
 	int diff = (visibleTiles.GetSize().x - Global::MIN_PADDING) / 2 - fov;
 	int diff_z = visibleTiles.GetSize().z / 2 - fovZ;
 
-	GridTransformation transformation;
+	uf::GridTransformation transformation;
 	transformation.originDelta = {diff, diff, diff_z};
 	transformation.sizeDelta = -(transformation.originDelta * 2);
 

--- a/OSS13 Server/Sources/World/Map.cpp
+++ b/OSS13 Server/Sources/World/Map.cpp
@@ -32,8 +32,8 @@ void Map::Update(std::chrono::microseconds timeElapsed) {
 apos Map::GetSize() const { return tiles.GetSize(); }
 Atmos* Map::GetAtmos() const { return atmos.get(); }
 
-Tile *Map::GetTile(vec3i pos) const {
-    if (pos >= vec3i(0) && pos < GetSize())
+Tile *Map::GetTile(uf::vec3i pos) const {
+    if (pos >= uf::vec3i(0) && pos < GetSize())
         return tiles.At(pos).get();
     return nullptr;
 }

--- a/OSS13 Server/Sources/World/Map.cpp
+++ b/OSS13 Server/Sources/World/Map.cpp
@@ -9,13 +9,8 @@
 Map::Map(const uint sizeX, const uint sizeY, const uint sizeZ)
 {
 	tiles.SetSize(sizeX, sizeY, sizeZ);
-	for (uint z = 0; z < sizeZ; z++) {
-		for (uint y = 0; y < sizeY; y++) {
-			for (uint x = 0; x < sizeX; x++) {
-				uptr<Tile> &cell = tiles.At(apos(x, y, z));
-				cell = std::make_unique<Tile>(this, apos(x, y, z));
-			}
-		}
+	for (auto &&[cell, pos] : tiles) {
+		cell = std::make_unique<Tile>(this, pos);
 	}
 	LOGI << "Map is created with size: " << sizeX << "x" << sizeY << "x" << sizeZ;
 
@@ -23,13 +18,13 @@ Map::Map(const uint sizeX, const uint sizeY, const uint sizeZ)
 }
 
 void Map::ClearDiffs() {
-	for (auto &tile : tiles.Get())
+	for (auto &tile : tiles.Items())
 		tile->ClearDiffs();
 	network::protocol::Diff::ResetDiffCounter();
 }
 
 void Map::Update(std::chrono::microseconds timeElapsed) {
-    for (auto &tile : tiles.Get())
+    for (auto &tile : tiles.Items())
 		tile->Update(timeElapsed);
     atmos->Update(timeElapsed);
 }
@@ -42,5 +37,3 @@ Tile *Map::GetTile(vec3i pos) const {
         return tiles.At(pos).get();
     return nullptr;
 }
-
-const vector< uptr<Tile>>& Map::GetTiles() const { return tiles.Get(); }

--- a/OSS13 Server/Sources/World/Map.hpp
+++ b/OSS13 Server/Sources/World/Map.hpp
@@ -20,7 +20,6 @@ public:
     apos GetSize() const;
     Atmos *GetAtmos() const;
     Tile *GetTile(vec3i) const;
-    const vector<uptr<Tile>> &GetTiles() const;
 
 private:
     uptr<Atmos> atmos;

--- a/OSS13 Server/Sources/World/Map.hpp
+++ b/OSS13 Server/Sources/World/Map.hpp
@@ -8,7 +8,6 @@
 #include "Shared/Grid.hpp"
 
 using std::vector;
-using namespace uf;
 
 class Map {
 public:
@@ -19,10 +18,10 @@ public:
 
     apos GetSize() const;
     Atmos *GetAtmos() const;
-    Tile *GetTile(vec3i) const;
+    Tile *GetTile(uf::vec3i) const;
 
 private:
     uptr<Atmos> atmos;
 
-    Grid<uptr<Tile>> tiles;
+    uf::Grid<uptr<Tile>> tiles;
 };

--- a/OSS13 Server/Sources/World/Objects/Object.cpp
+++ b/OSS13 Server/Sources/World/Objects/Object.cpp
@@ -89,25 +89,25 @@ void Object::Move(uf::vec2i order) {
 		if (order.y) moveIntent.y = order.y;
 
 		Tile *newTileX = tile->GetMap()->GetTile({ tile->GetPos().x + moveIntent.x, tile->GetPos().y, tile->GetPos().z });
-		Direction xDirection = newTileX ? uf::VectToDirection(newTileX->GetPos() - tile->GetPos()) : uf::Direction::NONE;
+		uf::Direction xDirection = newTileX ? uf::VectToDirection(newTileX->GetPos() - tile->GetPos()) : uf::Direction::NONE;
 
 		Tile *newTileY = tile->GetMap()->GetTile({ tile->GetPos().x, tile->GetPos().y + moveIntent.y, tile->GetPos().z });
-		Direction yDirection = newTileY ? uf::VectToDirection(newTileY->GetPos() - tile->GetPos()) : uf::Direction::NONE;
+		uf::Direction yDirection = newTileY ? uf::VectToDirection(newTileY->GetPos() - tile->GetPos()) : uf::Direction::NONE;
 
 		Tile *newTileDiag = tile->GetMap()->GetTile(tile->GetPos() + rpos(moveIntent, 0));
 
 		if (GetDensity()) {
 			auto moveDirection = uf::VectToDirection(moveIntent);
 
-			if (tile->IsDense(DirectionSet({moveDirection}))) { // exit from current tile
+			if (tile->IsDense(uf::DirectionSet({moveDirection}))) { // exit from current tile
 				moveIntent = GetMoveIntent();
 			} else {
-				if (!newTileDiag || newTileDiag->IsDense((DirectionSet({uf::InvertDirection(moveDirection), uf::Direction::CENTER})))) {
+				if (!newTileDiag || newTileDiag->IsDense((uf::DirectionSet({uf::InvertDirection(moveDirection), uf::Direction::CENTER})))) {
 					return;
 				}
 				else {
-					if (!newTileX || newTileX != tile && newTileX->IsDense((DirectionSet({ uf::InvertDirection(xDirection), yDirection, uf::Direction::CENTER })))) return;
-					if (!newTileY || newTileY != tile && newTileY->IsDense((DirectionSet({ uf::InvertDirection(yDirection), xDirection, uf::Direction::CENTER })))) return;
+					if (!newTileX || newTileX != tile && newTileX->IsDense((uf::DirectionSet({ uf::InvertDirection(xDirection), yDirection, uf::Direction::CENTER })))) return;
+					if (!newTileY || newTileY != tile && newTileY->IsDense((uf::DirectionSet({ uf::InvertDirection(yDirection), xDirection, uf::Direction::CENTER })))) return;
 				}
 			}
 		}

--- a/OSS13 Server/Sources/World/Tile.cpp
+++ b/OSS13 Server/Sources/World/Tile.cpp
@@ -112,9 +112,9 @@ bool Tile::MoveTo(Object *obj) {
 	uf::Direction direction = uf::VectToDirection(delta);
 
 	if (obj->GetDensity()) {
-		auto bumpedTo = lastTile->GetDenseObject(DirectionSet({ direction }));
+		auto bumpedTo = lastTile->GetDenseObject(uf::DirectionSet({ direction }));
 		if (!bumpedTo)
-			bumpedTo = GetDenseObject(DirectionSet({uf::InvertDirection(direction), uf::Direction::CENTER}));
+			bumpedTo = GetDenseObject(uf::DirectionSet({uf::InvertDirection(direction), uf::Direction::CENTER}));
 		if (bumpedTo) {
 			obj->BumpedTo(bumpedTo);
 			return false;
@@ -200,7 +200,7 @@ const std::list<Object *> &Tile::Content() const {
     return content;
 }
 
-Object *Tile::GetDenseObject(DirectionSet directions) const
+Object *Tile::GetDenseObject(uf::DirectionSet directions) const
 {
     for (auto &obj : content)
         if (obj->GetSolidity().DoesExistOne(directions)) return obj;

--- a/SharedLibrary/Sources/Shared/Grid.hpp
+++ b/SharedLibrary/Sources/Shared/Grid.hpp
@@ -3,6 +3,8 @@
 #include <functional>
 #include <vector>
 
+#include <Shared/IFaces/ICopyable.h>
+#include <Shared/Range.hpp>
 #include <Shared/Types.hpp>
 
 namespace uf {
@@ -13,21 +15,43 @@ struct GridTransformation {
 };
 
 template<typename T>
-class Grid {
+class Grid: public ICopyable {
 public:
-	Grid() {};
+	typedef typename std::vector<T>::iterator        flat_iterator;
+	typedef typename std::vector<T>::const_iterator  const_flat_iterator;
+	typedef typename std::vector<T>::reference       reference;
+	typedef typename std::vector<T>::const_reference const_reference;
+
+	class iterator {
+		Grid<T>& grid;
+		vec3u dataPos;
+	public:
+		iterator(Grid<T>& _grid): grid(_grid) {};
+		iterator(Grid<T>& _grid, vec3u _dataPos): grid(_grid), dataPos(_dataPos) {};
+		iterator& operator++();
+		std::pair<reference, vec3u> operator*();
+		bool operator!=(const iterator& it) const;
+	};
+
 	void SetSize(vec3u size);
 	void SetSize(uint x, uint y, uint z);
 	vec3u GetSize() const;
-	std::vector<T>& Get();
-	const std::vector<T>& Get() const;
+
+	iterator begin();
+	iterator end();
+
+	const Range<flat_iterator> Items();
+	const Range<const_flat_iterator> Items() const;
+
+	reference       At(vec3u pos);
+	reference       At(uint x, uint y, uint z);
+	const_reference At(vec3u pos) const;
+	const_reference At(uint x, uint y, uint z) const;
+
 	void SetMovedCallback(std::function<void(vec3u, vec3u)> movedCallback);
 	void SetRemovedCallback(std::function<void(vec3u)> removedCallback);
+
 	void Transform(const GridTransformation transformation);
-	typename std::vector<T>::reference At(vec3u pos);
-	typename std::vector<T>::reference At(uint x, uint y, uint z);
-	typename std::vector<T>::const_reference At(vec3u pos) const;
-	typename std::vector<T>::const_reference At(uint x, uint y, uint z) const;
 private:
 	static uint flatIndex (const vec3u xyz, uint w, uint h);
 	vec3u dataSize;

--- a/SharedLibrary/Sources/Shared/Range.hpp
+++ b/SharedLibrary/Sources/Shared/Range.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <Shared/IFaces/ICopyable.h>
+
+namespace uf {
+
+template<class T>
+class Range: public ICopyable {
+	const T _begin;
+	const T _end;
+public:
+	Range(T begin, T end): _begin(std::move(begin)), _end(std::move(end)) {}
+	const T& begin() const {
+		return _begin;
+	}
+	const T& end() const {
+		return _end;
+	}
+};
+
+template<class T>
+auto MakeRange(T& container) {
+	return Range<typename std::conditional<std::is_const<T>::value, class T::const_iterator, class T::iterator>::type>(container.begin(), container.end());
+}
+
+} // namespace uf


### PR DESCRIPTION
- Add `Range`, a wrapper for iterables.
- Add `Grid` iterator.
- Replace `Grid::Get` with `Grid::Items` that doesn't leak implementation details.