### PR TITLE
Pure directed sprites

### DIFF
--- a/OSS13 Client/Sources/Graphics/Sprite.cpp
+++ b/OSS13 Client/Sources/Graphics/Sprite.cpp
@@ -1,82 +1,137 @@
 #include "Sprite.hpp"
 
-#include <string>
-
-#include "Client.hpp"
-#include "Window.hpp"
-
 #include <SFML/Graphics.hpp>
 
-using std::string;
+#include <Shared/Geometry/Angle.h>
+#include <Shared/ErrorHandling.h>
 
-Sprite::Sprite() :
-    texture(nullptr),
-	firstFrame(0),
-	frames(1),
-	directed(false),
-	curFrame(0),
-	direction(uf::Direction::NONE),
-	scale(1)
-{ }
+#include <Client.hpp>
+
+#include "Window.hpp"
+
+namespace {
+
+uf::Angle getSpriteAngle(uf::Direction direction) {
+	// for uf::Direction::SOUTH should return zero angle
+	return uf::DirectionToAngle(direction) + uf::Angle::Degrees(90);
+}
+
+} // namespace
+
+Sprite::Sprite(const SpriteInfo &recipe, Global::ItemSpriteState state) {
+	initializeFromRecipe(recipe, state);
+	updateSpriteVariables();
+}
 
 void Sprite::Draw(sf::RenderTarget *target, uf::vec2i pos, sf::RenderStates rs) const {
-    sfSprite.setPosition(pos);
-    target->draw(sfSprite, rs);
+	sfSprite.setPosition(pos + origin);
+	target->draw(sfSprite, rs);
 }
 
 void Sprite::Resize(int tileSize) {
-    scale = float(tileSize) / texture->GetSizeOfTile();
-    sfSprite.setScale(scale, scale);
+	scale = float(tileSize) / texture->GetSizeOfTile();
+	sfSprite.setScale(scale, scale);
 }
 
 bool Sprite::Update(sf::Time timeElapsed) {
-    if (frames > 1) {
-        curFrameTime += timeElapsed;
-        if (curFrameTime >= frameTime) {
-            curFrameTime = sf::Time();
-            curFrame++;
-            if (curFrame >= frames) {
-                curFrame = 0;
-                updateSpriteVariables();
-                return true;
-            }
-            updateSpriteVariables();
-        }
-        return false;
-    }
-    return true;
+	if (frames > 1) {
+		curFrameTime += timeElapsed;
+		if (curFrameTime >= frameTime) {
+			curFrameTime = sf::Time();
+			curFrame++;
+			if (curFrame >= frames) {
+				curFrame = 0;
+				updateSpriteVariables();
+				return true;
+			}
+			updateSpriteVariables();
+		}
+		return false;
+	}
+	return true;
 }
 
 void Sprite::SetDirection(uf::Direction direction) {
-    this->direction = direction;
-    updateSpriteVariables();
+	this->direction = direction;
+	updateSpriteVariables();
 }
 
 const std::string &Sprite::GetKey() const { return key; }
 bool Sprite::IsValid() const { return texture; }
 bool Sprite::IsAnimated() const { return frames > 1; }
+
 bool Sprite::PixelTransparent(uf::vec2u pixel) const {
-    auto real_pixel = pixel / scale;
-    if (texture->IsFramePixelTransparent(real_pixel, curFrame + firstFrame)) return true;
-    return false;
-}
-
-void Sprite::updateSpriteVariables() {
-    if (!texture)
-        return;
-
-    int realState = firstFrame;
-    if (directed && direction != uf::Direction::NONE) realState += int(direction) * frames;
-    if (frames > 1) realState += curFrame;
-
-    rect.left = realState % texture->GetNumOfTiles().x * texture->GetSizeOfTile();
-    rect.top = realState / texture->GetNumOfTiles().x * texture->GetSizeOfTile();
-    rect.width = rect.height = texture->GetSizeOfTile();
-
-    sfSprite.setTexture(*texture->GetSFMLTexture());
-    sfSprite.setTextureRect(rect);
+	auto real_pixel = pixel / scale;
+	auto rotated_pixel = (real_pixel - origin).rotate(-getSpriteAngle(direction)) + origin;
+	if (texture->IsFramePixelTransparent(rotated_pixel, curFrame + firstFrame)) return true;
+	return false;
 }
 
 const sf::Sprite &Sprite::GetSfmlSprite() const {
 	return sfSprite;
+}
+
+void Sprite::initializeFromRecipe(const SpriteInfo &recipe, Global::ItemSpriteState state) {
+	key = recipe.title;
+
+	switch (state) {
+		case Global::ItemSpriteState::DEFAULT:
+		{
+			texture = recipe.texture;
+			firstFrame = recipe.firstFrame;
+			frames = recipe.frames;
+			frameTime = recipe.frameTime;
+			directed = recipe.directed;
+			pureDirections = recipe.pureDirections;
+			break;
+		};
+		case Global::ItemSpriteState::ON_MOB:
+		{
+			texture = recipe.mobState_texture;
+			firstFrame = recipe.mobState_firstFrame;
+			directed = true;
+			break;
+		}
+		case Global::ItemSpriteState::IN_HAND_LEFT:
+		{
+			texture = recipe.lhandState_texture;
+			firstFrame = recipe.lhandState_firstFrame;
+			directed = true;
+			break;
+		}
+		case Global::ItemSpriteState::IN_HAND_RIGHT:
+		{
+			texture = recipe.rhandState_texture;
+			firstFrame = recipe.rhandState_firstFrame;
+			directed = true;
+			break;
+		}
+		default:
+			EXPECT_WITH_MSG(false, "Unknown state: " + std::to_string(static_cast<uint32_t>(state)));
+	}
+}
+
+void Sprite::updateSpriteVariables() {
+	if (!texture)
+		return;
+
+	int realState = firstFrame;
+	if (directed && direction != uf::Direction::NONE) {
+		if (!pureDirections)
+			realState += int(direction) * frames;
+		else {
+			sfSprite.setRotation(static_cast<float>(getSpriteAngle(direction).GetDegrees()));
+		}
+	}
+	if (frames > 1) realState += curFrame;
+
+	rect.left = realState % texture->GetNumOfTiles().x * texture->GetSizeOfTile();
+	rect.top = realState / texture->GetNumOfTiles().x * texture->GetSizeOfTile();
+	rect.width = rect.height = texture->GetSizeOfTile();
+
+	origin = uf::vec2f(static_cast<float>(texture->GetSizeOfTile())) / 2;
+
+	sfSprite.setTexture(*texture->GetSFMLTexture());
+	sfSprite.setTextureRect(rect);
+	sfSprite.setOrigin(origin);
 }

--- a/OSS13 Client/Sources/Graphics/Sprite.hpp
+++ b/OSS13 Client/Sources/Graphics/Sprite.hpp
@@ -1,49 +1,50 @@
 #pragma once
 
+#include <Shared/Global.hpp>
+#include <Shared/Types.hpp>
+#include <Shared/IFaces/ICopyable.h>
+
 #include "Texture.hpp"
-#include "Shared/Types.hpp"
+#include "SpriteInfo.h"
 
-class SpriteFactory;
-
-class Sprite {
+class Sprite : public ICopyable {
 public:
-    friend SpriteFactory;
+	Sprite() = default;
+	Sprite(const SpriteInfo &recipe, Global::ItemSpriteState state);
 
-    Sprite();
-    Sprite(const Sprite &) = default;
-    Sprite &operator=(const Sprite &) = default;
-    Sprite(Sprite &&) = default;
-    Sprite &operator=(Sprite &&) = default;
+	void Draw(sf::RenderTarget *, uf::vec2i pos, sf::RenderStates rs = sf::RenderStates::Default) const;
+	// true if frame changed to the first
+	bool Update(sf::Time timeElapsed);
+	void Resize(int tileSize);
 
-    void Draw(sf::RenderTarget *, uf::vec2i pos, sf::RenderStates rs = sf::RenderStates::Default) const;
-    // true if frame changed to the first
-    bool Update(sf::Time timeElapsed);
-    void Resize(int tileSize);
-    
-    void SetDirection(uf::Direction direction);
+	void SetDirection(uf::Direction direction);
 
-    const std::string &GetKey() const;
-    // true if sprite has few frames
-    bool IsValid() const;
-    bool IsAnimated() const;
-    bool PixelTransparent(uf::vec2u pixel) const;
+	const std::string &GetKey() const;
+	// true if sprite has few frames
+	bool IsValid() const;
+	bool IsAnimated() const;
+	bool PixelTransparent(uf::vec2u pixel) const;
 	const sf::Sprite &GetSfmlSprite() const;
 
 private:
-    mutable sf::Sprite sfSprite;
+	void initializeFromRecipe(const SpriteInfo &recipe, Global::ItemSpriteState state);
+	void updateSpriteVariables();
 
-    const Texture *texture;
-    std::string key;
-    uint firstFrame;
-    uint frames;
-    sf::Time frameTime;
-    bool directed;
+private:
+	const Texture *texture{};
+	std::string key;
+	uint firstFrame{};
+	uint frames{1};
+	sf::Time frameTime;
+	bool directed{};
+	bool pureDirections{};
 
-    uint curFrame;
-    uf::Direction direction;
-    float scale;
-    sf::Rect<int> rect;
-    sf::Time curFrameTime;
+	uint curFrame{};
+	uf::Direction direction{uf::Direction::NONE};
+	float scale{1};
+	sf::Rect<int> rect;
+	uf::vec2f origin;
+	sf::Time curFrameTime;
 
-    void updateSpriteVariables();
+	mutable sf::Sprite sfSprite;
 };

--- a/OSS13 Client/Sources/Graphics/SpriteFactory.cpp
+++ b/OSS13 Client/Sources/Graphics/SpriteFactory.cpp
@@ -3,55 +3,15 @@
 #include <Client.hpp>
 
 #include <Shared/Global.hpp>
+#include <Shared/ErrorHandling.h>
 
 Sprite SpriteFactory::CreateSprite(uint32_t id) {
-	if (!id--) // should be from 1 to Global::MAX_SPRITE_ID! Decrease it to use as index
-		throw std::exception(); // "ID is null!"
+	EXPECT_WITH_MSG(id--, "ID is null!");
 
 	auto state = static_cast<Global::ItemSpriteState>(id & uint32_t(Global::ItemSpriteState::MASK));
 	id -= uint32_t(state);
 	
-	if (id < recipes.size()) {
-		Sprite sprite;
+	EXPECT_WITH_MSG(id < recipes.size(), "ID miss!");
 
-		sprite.key = recipes[id].title;
-
-		switch (state) {
-			case Global::ItemSpriteState::DEFAULT: {
-				sprite.texture = recipes[id].texture;
-				sprite.firstFrame = recipes[id].firstFrame;
-				sprite.frames = recipes[id].frames;
-				sprite.frameTime = recipes[id].frameTime;
-				sprite.directed = recipes[id].directed;
-				break;
-			};
-			case Global::ItemSpriteState::ON_MOB: {
-				sprite.texture = recipes[id].mobState_texture;
-				sprite.firstFrame = recipes[id].mobState_firstFrame;
-				sprite.directed = true;
-				break;
-			}
-			case Global::ItemSpriteState::IN_HAND_LEFT:
-			{
-				sprite.texture = recipes[id].lhandState_texture;
-				sprite.firstFrame = recipes[id].lhandState_firstFrame;
-				sprite.directed = true;
-				break;
-			}
-			case Global::ItemSpriteState::IN_HAND_RIGHT:
-			{
-				sprite.texture = recipes[id].rhandState_texture;
-				sprite.firstFrame = recipes[id].rhandState_firstFrame;
-				sprite.directed = true;
-				break;
-			}
-			default:
-				throw std::exception(); // "Sprite state is unknown!"
-		}
-
-		sprite.updateSpriteVariables();
-		return sprite;
-	}
-
-	throw std::exception(); // "ID miss!"
+	return Sprite(recipes[id], state);
 }

--- a/OSS13 Client/Sources/Graphics/SpriteInfo.h
+++ b/OSS13 Client/Sources/Graphics/SpriteInfo.h
@@ -11,17 +11,18 @@ struct SpriteInfo
 	std::string title;
 
 	const Texture *texture;
-	uint32_t firstFrame;
-	uint32_t frames;
+	uint32_t firstFrame{};
+	uint32_t frames{};
 	sf::Time frameTime;
-	bool directed;
+	bool directed{};
+	bool pureDirections{};
 
-	const Texture *mobState_texture;
-	uint32_t mobState_firstFrame;
+	const Texture *mobState_texture{};
+	uint32_t mobState_firstFrame{};
 
-	const Texture *lhandState_texture;
-	uint32_t lhandState_firstFrame;
+	const Texture *lhandState_texture{};
+	uint32_t lhandState_firstFrame{};
 
-	const Texture *rhandState_texture;
-	uint32_t rhandState_firstFrame;
+	const Texture *rhandState_texture{};
+	uint32_t rhandState_firstFrame{};
 };

--- a/OSS13 Client/Sources/Graphics/TileGrid/TileGrid.cpp
+++ b/OSS13 Client/Sources/Graphics/TileGrid/TileGrid.cpp
@@ -58,8 +58,6 @@ void TileGrid::drawContainer() const {
 	buffer.clear();
 	const int border = fov + Global::MIN_PADDING;
 
-	uf::vec2i cursorTilePosition;
-
     // Firstly, fill layers buffer by objects
     uf::vec2i tilePos; // tiles positions relative to camera
     for (tilePos.y = -border; tilePos.y <= border; tilePos.y++)
@@ -85,7 +83,6 @@ void TileGrid::drawContainer() const {
             object->Draw(&buffer, pixel);
             if (cursorPosition >= pixel && cursorPosition < pixel + uf::vec2i(tileSize)) {
 				underCursorTile = tile;
-				cursorTilePosition = cursorPosition - pixel;
                 if (!object->PixelTransparent(cursorPosition - pixel))
                     underCursorObject = object;
             }

--- a/OSS13 Client/Sources/Graphics/TileGrid/TileGrid.hpp
+++ b/OSS13 Client/Sources/Graphics/TileGrid/TileGrid.hpp
@@ -33,7 +33,7 @@ public:
 	bool OnMouseWheelScrolled(float delta, uf::vec2i position) final;
 	bool OnKeyPressed(sf::Event::KeyEvent keyEvent) final;
 
-	void AdjustSize(const uf::vec2i &windowSize);
+	void SetSize(const uf::vec2i &windowSize) final;
 
     //// FOR NETWORK
 
@@ -84,9 +84,6 @@ private:
 
 	int fov{0};
 	int fovZ{0};
-
-    // TileGrid padding
-    uf::vec2i padding;
 
     apos firstTile;
     int visibleTilesSide;

--- a/OSS13 Client/Sources/Graphics/UI/UIModule/GameProcessUI.cpp
+++ b/OSS13 Client/Sources/Graphics/UI/UIModule/GameProcessUI.cpp
@@ -64,20 +64,27 @@ void GameProcessUI::Receive(const std::string &message) {
 
 
 void GameProcessUI::Resize(const int width, const int height) {
-    tileGrid->AdjustSize(uf::vec2i(width, height));
-    infoLabel->CountPosition(width, height);
+	TileGrid *tileGrid = reinterpret_cast<GameProcessUI *>(CC::Get()->GetUI()->GetCurrentUIModule())->GetTileGrid();
 
-    TileGrid *tileGrid = reinterpret_cast<GameProcessUI *>(CC::Get()->GetUI()->GetCurrentUIModule())->GetTileGrid();
+	auto tileGridNumOfTiles = tileGrid->GetFOV() * 2 + 1;
+	auto tileSize = height / tileGridNumOfTiles;
+	auto tileGridSize = tileSize * tileGridNumOfTiles;
+	auto tileGridHeightPadding = (height - tileGridSize) / 2;
 
-    container->SetSize(sf::Vector2f(width - tileGrid->GetTileSize() * float(tileGrid->GetFOV()*2+1), height * 0.5f));
-    entry->SetSize({ container->GetSize().x, int(container->GetSize().y * 0.1f) });
-    formattedTextField->SetSize(uf::vec2i(container->GetSize().x, container->GetSize().y - entry->GetSize().y));
+	tileGrid->SetPosition({0, tileGridHeightPadding});
+	tileGrid->SetSize({tileGridSize, tileGridSize});
 
-    entry->SetPosition(0, float(formattedTextField->GetSize().y));
-    container->SetPosition({ width - container->GetSize().x, height - entry->GetSize().y - formattedTextField->GetSize().y });
+	infoLabel->CountPosition(width, height);
 
-    functionWindow->SetPosition(tileGrid->GetTileSize() * float(tileGrid->GetFOV()*2+1), 0);
-    functionWindow->SetSize({width - functionWindow->GetAbsolutePosition().x, container->GetPosition().y});
+	container->SetSize({width - tileGridSize, height / 2});
+	entry->SetSize({container->GetSize().x, container->GetSize().y / 10});
+	formattedTextField->SetSize(uf::vec2i{container->GetSize().x, container->GetSize().y - entry->GetSize().y});
+
+	container->SetPosition({ tileGridSize, height - entry->GetSize().y - formattedTextField->GetSize().y });
+	entry->SetPosition(0, float(formattedTextField->GetSize().y));
+
+	functionWindow->SetPosition(static_cast<float>(tileGridSize), 0);
+	functionWindow->SetSize({width - functionWindow->GetAbsolutePosition().x, container->GetPosition().y});
 }
 
 void GameProcessUI::Draw(sf::RenderWindow *renderWindow) {

--- a/OSS13 Client/Sources/Graphics/UI/Widget/CustomWidget.cpp
+++ b/OSS13 Client/Sources/Graphics/UI/Widget/CustomWidget.cpp
@@ -107,7 +107,7 @@ uf::vec2i CustomWidget::GetAbsolutePosition() const {
 	return parent ? uf::vec2i(getPosition()) + parent->GetAbsolutePosition() : uf::vec2i(getPosition());
 }
 
-uf::vec2i CustomWidget::GetSize() const { return size; }
+uf::vec2i CustomWidget::GetSize() const { return size * GetScale().x; }
 
 uf::vec2i CustomWidget::GetAbsoluteSize() const { 
 	const Widget *widget = this;

--- a/OSS13 Client/Sources/ResourceManager.cpp
+++ b/OSS13 Client/Sources/ResourceManager.cpp
@@ -96,8 +96,16 @@ void ResourceManager::generateSprites(
 
 		// Directed
 		iter = sprite_config.find("directed");
-		if (iter != sprite_config.end()) spriteInfo.directed = iter->get<bool>();
-		else spriteInfo.directed = false;
+		if (iter != sprite_config.end()) {
+			if (iter->is_boolean()) {
+				spriteInfo.directed = iter->get<bool>();
+			} else {
+				if (iter->get<std::string>() == "pure") {
+					spriteInfo.directed = true;
+					spriteInfo.pureDirections = true;
+				}
+			}
+		}
 
 		spriteInfo.firstFrame = firstFrame;
 		if (mobState_texture)

--- a/Resources/Icons/turfs.json
+++ b/Resources/Icons/turfs.json
@@ -47,12 +47,12 @@
         {
             "sprite": "window",
             "frames": 1,
-            "directed": false
+            "directed": "pure"
         },
         {
             "sprite": "reinforced_window",
             "frames": 1,
-            "directed": false
+            "directed": "pure"
         }
     ]
 }

--- a/SharedLibrary/Sources/Shared/Geometry/Angle.h
+++ b/SharedLibrary/Sources/Shared/Geometry/Angle.h
@@ -15,6 +15,11 @@ public:
 	double Cos() const { return std::cos(radians); }
 	double Sin() const { return std::sin(radians); }
 
+	Angle operator-() { return Angle::Radians(-radians); }
+
+	Angle operator+(const Angle &other) { return Angle::Radians(radians + other.radians); }
+	Angle operator-(const Angle &other) { return Angle::Radians(radians - other.radians); }
+
 	Angle operator+=(const Angle &other) { radians += other.radians; return *this; }
 	Angle operator-=(const Angle &other) { radians -= other.radians; return *this; }
 
@@ -32,10 +37,5 @@ private:
 
 	double radians;
 };
-
-inline auto operator-(const Angle& angle) { return Angle::Radians(-angle.GetRadians()); }
-
-inline auto operator+(const Angle& left, const Angle& right) { return Angle::Radians(left.GetRadians() + right.GetRadians()); }
-inline auto operator-(const Angle& left, const Angle& right) { return Angle::Radians(left.GetRadians() - right.GetRadians()); }
 
 }

--- a/SharedLibrary/Sources/Shared/Geometry/Angle.h
+++ b/SharedLibrary/Sources/Shared/Geometry/Angle.h
@@ -9,11 +9,21 @@ public:
 	static Angle Radians(double radians) { return Angle(radians); }
 	static Angle Degrees(double degrees) { return Angle(uf::detail::DegressToRadians(degrees)); }
 
-	double GetRadians() { return radians; }
-	double GetDegrees() { return uf::detail::RadiansToDegrees(radians); }
+	double GetRadians() const { return radians; }
+	double GetDegrees() const { return uf::detail::RadiansToDegrees(radians); }
 
-	double Cos() { return std::cos(radians); }
-	double Sin() { return std::sin(radians); }
+	double Cos() const { return std::cos(radians); }
+	double Sin() const { return std::sin(radians); }
+
+	Angle operator+=(const Angle &other) { radians += other.radians; return *this; }
+	Angle operator-=(const Angle &other) { radians -= other.radians; return *this; }
+
+	bool operator==(const Angle &other) const { return radians == other.radians; }
+	bool operator!=(const Angle &other) const { return radians != other.radians; }
+	bool operator<=(const Angle &other) const { return radians <= other.radians; }
+	bool operator<(const Angle &other) const { return radians < other.radians; }
+	bool operator>=(const Angle &other) const { return radians >= other.radians; }
+	bool operator>(const Angle &other) const { return radians > other.radians; }
 
 private:
 	explicit Angle(double radians) : 
@@ -22,5 +32,10 @@ private:
 
 	double radians;
 };
+
+inline auto operator-(const Angle& angle) { return Angle::Radians(-angle.GetRadians()); }
+
+inline auto operator+(const Angle& left, const Angle& right) { return Angle::Radians(left.GetRadians() + right.GetRadians()); }
+inline auto operator-(const Angle& left, const Angle& right) { return Angle::Radians(left.GetRadians() - right.GetRadians()); }
 
 }

--- a/SharedLibrary/Sources/Shared/Geometry/Direction.cpp
+++ b/SharedLibrary/Sources/Shared/Geometry/Direction.cpp
@@ -50,6 +50,10 @@ vec2i DirectionToVect(Direction direction) {
 	}
 }
 
+Angle DirectionToAngle(Direction direction) {
+	return (DirectionToVect(direction) * -1).angle();
+}
+
 Direction InvertDirection(Direction direction) {
 	switch (direction) {
 		case Direction::SOUTH:

--- a/SharedLibrary/Sources/Shared/Geometry/Direction.hpp
+++ b/SharedLibrary/Sources/Shared/Geometry/Direction.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Angle.h"
 #include "Vec2.hpp"
 #include "Vec3.hpp"
 
@@ -21,6 +22,7 @@ enum class Direction : int {
 Direction VectToDirection(vec2f);
 Direction VectToDirection(vec3f);
 vec2i DirectionToVect(Direction);
+Angle DirectionToAngle(Direction);
 
 Direction InvertDirection(Direction);
 bool SplitDirection(const Direction &input, Direction &first, Direction &second);

--- a/SharedLibrary/Sources/Shared/Geometry/Vec2.hpp
+++ b/SharedLibrary/Sources/Shared/Geometry/Vec2.hpp
@@ -61,7 +61,7 @@ struct vec2<T> {
 	template<typename U>
 	operator sf::Vector2<U>() const;
 
-	std::string toString() { return "(" + std::to_string(x) + ", " + std::to_string(y) + ")"; }
+	std::string toString() const { return "(" + std::to_string(x) + ", " + std::to_string(y) + ")"; }
 };
 
 template<typename T>

--- a/SharedLibrary/Sources/Shared/Geometry/Vec2.inl
+++ b/SharedLibrary/Sources/Shared/Geometry/Vec2.inl
@@ -28,7 +28,7 @@ vec2<double> vec2<T>::unit() const {
 
 template <typename T>
 vec2<double> vec2<T>::rotate(Angle angle) const {
-	return vec2<double>(angle) * magnitude();
+	return vec2<double>::unit(angle + this->angle()) * magnitude();
 }
 
 template <typename T>

--- a/SharedLibrary/Sources/Shared/Global.hpp
+++ b/SharedLibrary/Sources/Shared/Global.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 namespace Global {
 
 const int PORT = 55700;


### PR DESCRIPTION
Add option for sprites to be pure directed. This means that instead of provide sprite's states for each direction, one direction rotates automatically.

+ Client Sprite refactoring
+ Angle arithmetics and DirectionToAngle function
+ vector minor fixes